### PR TITLE
docs: use newer go install syntax for the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Improvements, ideas and bug fixes are welcomed.
 Run the following command, which will build and install the latest binary in $GOPATH/bin
 
 ```
-go get github.com/miracl/conflate/...
+go install github.com/miracl/conflate/...@latest
 ```
 Alternatively, you can install one of the pre-built release binaries from https://github.com/miracl/conflate/releases
 


### PR DESCRIPTION
The `go get` syntax for installing packages is deprecated. More details in the official announcement: https://go.dev/doc/go-get-install-deprecation